### PR TITLE
Fix diego smoke tests to run in bosh lite AWS provider

### DIFF
--- a/templates/smoke-tests-bosh-lite.yml
+++ b/templates/smoke-tests-bosh-lite.yml
@@ -56,10 +56,10 @@ jobs:
   resource_pool: smoke-test
 
 properties:
-  domain: (( merge ))
+  domain: (( merge || "10.244.0.34.xip.io" ))
   diego:
     smoke_tests:
-      api: (( "api." properties.domain || api.10.244.0.34.xip.io ))
+      api: (( "api." properties.domain ))
       user: admin
       password: admin
       org: smoke-tests

--- a/templates/smoke-tests-bosh-lite.yml
+++ b/templates/smoke-tests-bosh-lite.yml
@@ -56,9 +56,10 @@ jobs:
   resource_pool: smoke-test
 
 properties:
+  domain: (( merge ))
   diego:
     smoke_tests:
-      api: api.10.244.0.34.xip.io
+      api: (( "api." properties.domain || api.10.244.0.34.xip.io ))
       user: admin
       password: admin
       org: smoke-tests


### PR DESCRIPTION
Hello.

In this pull request domain was added to properties in smoke-tests-bosh-lite.yml. This fix allow to run smoke tests on bosh lite using AWS provider. Usually, when you use bosh lite AWS provider you add your domain to properties along with director UUID, and then use spiff to create you manifest - this don't work before this fix, because domain was hard coded.