### PR TITLE
Add windows app lifecycle to support windows stacks [#90637182]

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -33,3 +33,8 @@ rootfs/cflinuxfs2.tar.gz:
   sha: !binary |-
     YjY5ZTY2M2FlOWRmNjY3NWVhZGE1MDAwOGU4ZWI1YjNkMGZkMzBjNQ==
   size: 218215420
+lifecycles/windows_app_lifecycle-4dcba80.tgz:
+  object_id: fc3b9004-67dd-4a01-8238-f4c02bfc9ff6
+  sha: !binary |-
+    OTQyNzhjMTQyY2UzNzlhMDZmMmViOGQzYzVhOWNiYWZjZjg5ZGE5ZA==
+  size: 812102

--- a/jobs/file_server/spec
+++ b/jobs/file_server/spec
@@ -10,6 +10,7 @@ packages:
   - file_server
   - buildpack_app_lifecycle
   - docker_app_lifecycle
+  - windows_app_lifecycle
 
 properties:
   diego.ssl.skip_cert_verify:

--- a/packages/windows_app_lifecycle/packaging
+++ b/packages/windows_app_lifecycle/packaging
@@ -1,0 +1,2 @@
+set -e
+cp lifecycles/windows_app_lifecycle-4dcba80.tgz ${BOSH_INSTALL_TARGET}/windows_app_lifecycle.tgz

--- a/packages/windows_app_lifecycle/spec
+++ b/packages/windows_app_lifecycle/spec
@@ -1,0 +1,5 @@
+---
+name: windows_app_lifecycle
+
+files:
+  - lifecycles/windows_app_lifecycle-4dcba80.tgz

--- a/templates/enable_diego_windows_in_cc.yml
+++ b/templates/enable_diego_windows_in_cc.yml
@@ -1,0 +1,10 @@
+---
+properties:
+  cc:
+    stacks:
+      - name: "lucid64"
+        description: "Ubuntu 10.04 on x86-64"
+      - name: "cflinuxfs2"
+        description: "Cloud Foundry Linux-based filesystem"
+      - name: "windows2012R2"
+        description: "Windows Server 2012 R2"

--- a/templates/jobs.yml
+++ b/templates/jobs.yml
@@ -285,6 +285,7 @@ properties:
 
   lifecycle_bundles:
     buildpack/lucid64: buildpack_app_lifecycle/buildpack_app_lifecycle.tgz
+    buildpack/windows2012R2: windows_app_lifecycle/windows_app_lifecycle.tgz
     docker: docker_app_lifecycle/docker_app_lifecycle.tgz
 
   syslog_daemon_config: ~


### PR DESCRIPTION
NB. To use windows stack, it is also neccessary to use
templates/enable_diego_windows_in_cc.yml in CF manifest generation. This
will specify lucid64 and windows stacks.