### PR TITLE
Update bosh dance instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ as you switch in and out of the directory.
 1. Do the BOSH dance:
 
         cd ~/workspace/cf-release
-        bosh create release --force
-        bosh -n upload release
+        bosh create release --force &&
+        bosh -n upload release &&
         bosh -n deploy
 
 1. Generate and target diego's manifest:
@@ -210,8 +210,8 @@ as you switch in and out of the directory.
 
 1. Dance some more:
 
-        bosh create release --force
-        bosh -n upload release
+        bosh create release --force &&
+        bosh -n upload release &&
         bosh -n deploy
 
 Now you can either run the DATs or deploy your own app.


### PR DESCRIPTION
The current bosh dance instructions have the unfortunate consequence that if you don't have a config/dev.yml and copy/paste it, Bosh will prompt you for the name of the release and receive the `bosh -n upload release` as the input. This fixes it so the prompt correctly waits for input.