### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ as you switch in and out of the directory.
             ~/deployments/bosh-lite/director.yml \
             ~/workspace/diego-release/stubs-for-cf-release/enable_consul_with_cf.yml \
             ~/workspace/diego-release/stubs-for-cf-release/enable_diego_ssh_in_cc.yml \
-            ~/workspace/diego-release/manifest-generation/bosh-lite-stubs/property-overrides.yml \
             > ~/deployments/bosh-lite/cf.yml
         bosh deployment ~/deployments/bosh-lite/cf.yml
 
@@ -190,7 +189,6 @@ as you switch in and out of the directory.
             ~/workspace/diego-release/stubs-for-cf-release/enable_consul_with_cf.yml \
             ~/workspace/diego-release/stubs-for-cf-release/enable_diego_windows_in_cc.yml \
             ~/workspace/diego-release/stubs-for-cf-release/enable_diego_ssh_in_cc.yml \
-            ~/workspace/diego-release/manifest-generation/bosh-lite-stubs/property-overrides.yml \
             > ~/deployments/bosh-lite/cf.yml
         bosh deployment ~/deployments/bosh-lite/cf.yml
 


### PR DESCRIPTION
The README instructions for generating the cf manifest include Diego's BOSH-Lite property overrides stub.  This should never be necessary.