### PR TITLE
pull in the bosh-lite stub or life is hell

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ as you switch in and out of the directory.
         cd ~/workspace/cf-release
         ./generate_deployment_manifest warden \
             ~/deployments/bosh-lite/director.yml \
+            ~/workspace/cf-release/bosh-lite/cf-stub-spiff.yml
             ~/workspace/diego-release/stubs-for-cf-release/enable_consul_with_cf.yml \
             ~/workspace/diego-release/stubs-for-cf-release/enable_diego_ssh_in_cc.yml \
             > ~/deployments/bosh-lite/cf.yml

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ as you switch in and out of the directory.
         cd ~/workspace/cf-release
         ./generate_deployment_manifest warden \
             ~/deployments/bosh-lite/director.yml \
-            ~/workspace/cf-release/bosh-lite/cf-stub-spiff.yml
+            ~/workspace/cf-release/bosh-lite/cf-stub-spiff.yml \
             ~/workspace/diego-release/stubs-for-cf-release/enable_consul_with_cf.yml \
             ~/workspace/diego-release/stubs-for-cf-release/enable_diego_ssh_in_cc.yml \
             > ~/deployments/bosh-lite/cf.yml

--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ as you switch in and out of the directory.
 
         cd ~/workspace/cf-release
         ./generate_deployment_manifest warden \
-            ~/deployments/bosh-lite/director.yml \
             ~/workspace/cf-release/bosh-lite/cf-stub-spiff.yml \
+            ~/deployments/bosh-lite/director.yml \
             ~/workspace/diego-release/stubs-for-cf-release/enable_consul_with_cf.yml \
             ~/workspace/diego-release/stubs-for-cf-release/enable_diego_ssh_in_cc.yml \
             > ~/deployments/bosh-lite/cf.yml


### PR DESCRIPTION
The bosh-lite stub enables sane security groups, like access to the load balancer. 

Deploying cf-release is easy using the bosh-lite/make_manifest script. But it apparently doesn't enable consul and ssh, required for Diego. I'll address improving the bosh-lite/make_manifest script to support Diego separately.

If we must do things the long way (these instructions are really tedious if you don't want to keep files ~/deployments/bosh-lite), at least let's pull in the bosh-lite stub so the experience with cf-release on bosh-lite isn't worse than when deployed without Diego.