### PR TITLE
Manifest generation should merge extral properties from collocated jobs

### DIFF
--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -523,6 +523,7 @@ jobs:
 
 properties:
   # -- Properties below are used by the metron_agent job from cf-release --
+  <<: (( merge ))
   metron_agent:
     deployment: (( name ))
   nats: # For metron_agent to talk to collector


### PR DESCRIPTION
When we are trying to add a collocated job into diego.

we found the properties of the collocated job will be ignored even if we put it into property-overrides.yml.
we need to add a 'merge' into the template so it could take the property for collocated job.

