### PR TITLE
Parameterize bosh-lite IP

### DIFF
--- a/scripts/print-director-stub
+++ b/scripts/print-director-stub
@@ -2,4 +2,4 @@
 
 set -e
 
-printf "director_uuid: %s" $(bosh -t 192.168.50.4 status --uuid)
+printf "director_uuid: %s" $(bosh -t ${DIRECTOR_IP:-192.168.50.4} status --uuid)


### PR DESCRIPTION
If anyone wants to deploy to a bosh-lite that's not local, the `generate-bosh-lite-manifests` script will not work because it's hardcoded to look for the `uuid` of the director at `192.168.50.4`.

We parameterized this--with the default of `192.168.50.4`--to allow overrides but have no impact otherwise.

Signed-off-by: Shash Reddy <sreddy@pivotal.io>