### PR TITLE
Re-enable btrfs and disk quotas on BOSH lite

### DIFF
--- a/manifest-generation/bosh-lite-stubs/property-overrides.yml
+++ b/manifest-generation/bosh-lite-stubs/property-overrides.yml
@@ -382,8 +382,6 @@ property_overrides:
   garden:
     listen_network: tcp
     listen_address: 0.0.0.0:7777
-    mount_btrfs_loopback: false
-    disk_quota_enabled: false
     log_level: debug
   nsync:
     log_level: debug


### PR DESCRIPTION
This is fine as long as you're using Garden-Linux-Release v0.306.0 or greater. It also makes performance on BOSH lite usable again!