### PR TITLE
Ability to set datacenter in templates (defaulting to "dc1")

### DIFF
--- a/manifest-generation/config-from-cf-internal.yml
+++ b/manifest-generation/config-from-cf-internal.yml
@@ -7,6 +7,7 @@ config_from_cf:
     staging_upload_user: (( properties.cc.staging_upload_user ))
     staging_upload_password: (( properties.cc.staging_upload_password ))
   consul:
+    datacenter: (( properties.consul.agent.datacenter || "dc1" ))
     log_level: (( properties.consul.agent.log_level ))
     lan_servers: (( properties.consul.agent.servers.lan ))
     ca_cert: (( properties.consul.ca_cert ))
@@ -48,6 +49,7 @@ properties:
   consul:
     agent:
       log_level: (( merge ))
+      datacenter: (( merge ))
       servers:
         lan: (( merge ))
     ca_cert:

--- a/manifest-generation/config-from-cf.yml
+++ b/manifest-generation/config-from-cf.yml
@@ -7,6 +7,7 @@ config_from_cf:
     staging_upload_user: (( merge ))
     staging_upload_password: (( merge ))
   consul:
+    datacenter: (( merge ))
     log_level: (( merge ))
     lan_servers: (( merge ))
     ca_cert: (( merge ))

--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -538,6 +538,7 @@ properties:
   # -- Property below is used by the consul_agent job from cf-release --
   consul:
     agent:
+      datacenter: (( config_from_cf.consul.datacenter ))
       log_level: (( config_from_cf.consul.log_level ))
       servers:
         lan: (( config_from_cf.consul.lan_servers ))


### PR DESCRIPTION
The template generation assumes that the cf install's consul isn't specifying the datacenter (simply using the default of `dc1`). This isn't true for our installation. This pull request allows the scripts to consume datacenter when present in the ingested cf manifest and defaults to `dc1` when not present.