### PR TITLE
Allow property overrides to configure etcd

### DIFF
--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -551,7 +551,7 @@ properties:
 
   # -- Proerties below are used by jobs from diego-release --
   etcd:
-    machines: ["etcd.service.cf.internal"]
+    machines: (( property_overrides.etcd.machines || ["etcd.service.cf.internal"] ))
     cluster:
       - name: "database_z1"
         instances: (( instance_count_overrides.database_z1.instances || 1 ))
@@ -604,7 +604,7 @@ properties:
       auctioneer:
         api_url: (( "http://auctioneer.service.cf.internal:9016" ))
       etcd:
-        machines: ["etcd.service.cf.internal"]
+        machines: (( property_overrides.etcd.machines || ["etcd.service.cf.internal"] ))
         require_ssl: (( property_overrides.etcd.require_ssl || nil ))
         ca_cert: (( property_overrides.etcd.ca_cert ))
         client_cert: (( property_overrides.etcd.client_cert ))


### PR DESCRIPTION
Currently, the other etcd properties can be overridden in `property_overrides`. We need to also be able to override `properties.etcd.machines` and `properties.diego.bbs.etcd.machines` in the same way.