### PR TITLE
clean up manifest generation, and a couple other things

### DIFF
--- a/manifest-generation/config-from-cf-internal.yml
+++ b/manifest-generation/config-from-cf-internal.yml
@@ -1,12 +1,14 @@
 config_from_cf:
-  cf_director_uuid: (( director_uuid ))
   cf_deployment_name: (( name ))
+  cf_director_uuid: (( director_uuid ))
+  cf_releases: (( releases ))
   cc:
     internal_api_password: (( properties.cc.internal_api_password ))
     srv_api_uri: (( properties.cc.srv_api_uri ))
     staging_upload_user: (( properties.cc.staging_upload_user ))
     staging_upload_password: (( properties.cc.staging_upload_password ))
   consul:
+    datacenter: (( properties.consul.datacenter ))
     log_level: (( properties.consul.agent.log_level ))
     lan_servers: (( properties.consul.agent.servers.lan ))
     ca_cert: (( properties.consul.ca_cert ))
@@ -16,29 +18,23 @@ config_from_cf:
     require_ssl: (( properties.consul.require_ssl ))
     server_cert: (( properties.consul.server_cert ))
     server_key: (( properties.consul.server_key ))
-  etcd:
-    machines: (( properties.etcd.machines ))
   loggregator:
-    etcd:
-      machines: (( properties.loggregator.etcd.machines ))
-  loggregator_endpoint:
+    etcd_machines: (( properties.loggregator.etcd.machines ))
     shared_secret: (( properties.loggregator_endpoint.shared_secret ))
+    traffic_controller_url: (( "wss://doppler." properties.system_domain ":443" ))
   nats:
     user: (( properties.nats.user ))
     password: (( properties.nats.password ))
-    port: 4222
+    port: (( properties.nats.port ))
     machines: (( properties.nats.machines ))
-  system_domain: (( properties.system_domain ))
   uaa:
-    url: (( properties.uaa.url ))
-    clients:
-      ssh-proxy:
-        secret: (( properties.uaa.clients.ssh-proxy.secret ))
-  cf_releases: (( releases ))
+    ssh_proxy_client_secret: (( properties.uaa.clients.ssh-proxy.secret ))
+    token_url: (( properties.uaa.url "/oauth/token" ))
 
 # The keys below should not be included in the final stub
-director_uuid: (( merge ))
 name: (( merge ))
+director_uuid: (( merge ))
+releases: (( merge ))
 properties:
   cc:
     internal_api_password: (( merge ))
@@ -46,19 +42,18 @@ properties:
     staging_upload_user: (( merge ))
     staging_upload_password: (( merge ))
   consul:
+    datacenter: (( merge || nil ))
     agent:
       log_level: (( merge ))
       servers:
         lan: (( merge ))
-    ca_cert:
-    agent_cert:
-    agent_key:
-    encrypt_keys:
-    require_ssl:
-    server_cert:
-    server_key:
-  etcd:
-    machines: (( merge ))
+    ca_cert: (( merge || nil ))
+    agent_cert: (( merge || nil ))
+    agent_key: (( merge || nil ))
+    encrypt_keys: (( merge || nil ))
+    require_ssl: (( merge || nil ))
+    server_cert: (( merge || nil ))
+    server_key: (( merge || nil ))
   loggregator:
     etcd:
       machines: (( merge ))
@@ -68,10 +63,10 @@ properties:
     user: (( merge ))
     password: (( merge ))
     machines: (( merge ))
+    port: (( merge ))
   system_domain: (( merge ))
   uaa:
     clients:
       ssh-proxy:
         secret: (( merge || nil ))
-    url: (( merge || nil ))
-releases: (( merge ))
+    url: (( merge ))

--- a/manifest-generation/config-from-cf.yml
+++ b/manifest-generation/config-from-cf.yml
@@ -1,12 +1,14 @@
 config_from_cf:
-  cf_director_uuid: (( merge ))
   cf_deployment_name: (( merge ))
+  cf_director_uuid: (( merge ))
+  cf_releases: (( merge ))
   cc:
     internal_api_password: (( merge ))
     srv_api_uri: (( merge ))
     staging_upload_user: (( merge ))
     staging_upload_password: (( merge ))
   consul:
+    datacenter: (( merge ))
     log_level: (( merge ))
     lan_servers: (( merge ))
     ca_cert: (( merge ))
@@ -16,22 +18,15 @@ config_from_cf:
     require_ssl: (( merge ))
     server_cert: (( merge ))
     server_key: (( merge ))
-  etcd:
-    machines: (( merge ))
   loggregator:
-    etcd:
-      machines: (( merge ))
-  loggregator_endpoint:
+    etcd_machines: (( merge ))
     shared_secret: (( merge ))
+    traffic_controller_url: (( merge ))
   nats:
     user: (( merge ))
     password: (( merge ))
     port: (( merge ))
     machines: (( merge ))
-  system_domain: (( merge ))
   uaa:
-    clients:
-      ssh-proxy:
-        secret: (( merge ))
-    url: (( merge || nil ))
-  cf_releases: (( merge ))
+    ssh_proxy_client_secret: (( merge ))
+    token_url: (( merge ))

--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -528,15 +528,16 @@ properties:
     port: (( config_from_cf.nats.port ))
   loggregator:
     etcd:
-      machines: (( config_from_cf.loggregator.etcd.machines ))
+      machines: (( config_from_cf.loggregator.etcd_machines ))
   loggregator_endpoint:
-    shared_secret: (( config_from_cf.loggregator_endpoint.shared_secret ))
+    shared_secret: (( config_from_cf.loggregator.shared_secret ))
   syslog_daemon_config:
     address: (( property_overrides.syslog_daemon_config.address || nil ))
     port: (( property_overrides.syslog_daemon_config.port || nil ))
 
   # -- Property below is used by the consul_agent job from cf-release --
   consul:
+    datacenter: (( config_from_cf.consul.datacenter ))
     agent:
       log_level: (( config_from_cf.consul.log_level ))
       servers:
@@ -691,8 +692,8 @@ properties:
       servers: (( jobs.access_z1.networks.diego1.static_ips jobs.access_z2.networks.diego2.static_ips jobs.access_z3.networks.diego3.static_ips jobs.colocated_z1.networks.diego1.static_ips jobs.colocated_z2.networks.diego2.static_ips jobs.colocated_z3.networks.diego3.static_ips ))
       enable_cf_auth: (( property_overrides.ssh_proxy.enable_cf_auth || false ))
       enable_diego_auth: (( property_overrides.ssh_proxy.enable_diego_auth || false ))
-      uaa_secret: (( config_from_cf.uaa.clients.ssh-proxy.secret || nil ))
-      uaa_token_url: (( config_from_cf.uaa.url "/oauth/token" || nil ))
+      uaa_secret: (( config_from_cf.uaa.ssh_proxy_client_secret ))
+      uaa_token_url: (( config_from_cf.uaa.token_url ))
       diego_credentials: (( property_overrides.ssh_proxy.diego_credentials || nil ))
     stager:
       cc:
@@ -725,7 +726,7 @@ properties:
         client_session_cache_size: (( property_overrides.bbs.client_session_cache_size || nil ))
         max_idle_conns_per_host: (( property_overrides.bbs.max_idle_conns_per_host || nil ))
       log_level: (( property_overrides.tps.log_level || nil ))
-      traffic_controller_url: (( "wss://doppler." config_from_cf.system_domain ":443" ))
+      traffic_controller_url: (( config_from_cf.loggregator.traffic_controller_url ))
 
   # -- Proerties below are used by jobs from garden-linux-release --
   garden:

--- a/stubs-for-cf-release/enable_consul_with_cf.yml
+++ b/stubs-for-cf-release/enable_consul_with_cf.yml
@@ -1,4 +1,0 @@
----
-jobs:
-  - name: consul_z1
-    instances: 1


### PR DESCRIPTION
This mostly introduces the following changes to `manifest-generation`

* the bottom part of `config-from-cf-internal.yml` is **only** responsible for pulling data from the CF manifest, and defaults to nil **if and only if** it's possible for that data is not provided in the CF manifest.
* the top part of `config-from-cf-internal.yml` transforms the extracted data into data diego's manifest needs
* `config-from-cf.yml` is now **only** for masking off unneeded values from config-from-cf-internal
* `diego.yml` now only directly consumes values from the result of `config-from-cf.yml`, and does do any more transformation, with the sole exception of the deployment name being the CF name plus "-diego".

Additionally, this:

* deletes the unused `etcd.machines` property
* adds the `consul.datacenter` property
* removes `stubs-for-cf-release/enable_consul_with_cf.yml` which has long been redundant

I tried to validate this by generating a BOSH-Lite diego manifest before and after the changes, the only difference was the addition of the `consul.datacenter: null` value, as expected.  I didn't try it against other environments (ketchup, A1, etc.) but that would be easy enough to do.

NB: This builds on cloudfoundry-incubator/diego-release#97, please make sure @cholick gets credit for the idea via the git committer/author should you decide to merge this PR.