### PR TITLE
Allowed to set filename for $development

### DIFF
--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -1,6 +1,6 @@
 name: (( config_from_cf.cf_deployment_name "-diego" ))
 
-releases: (( base_releases additional_jobs.releases config_from_cf.cf_releases ))
+releases: (( base_releases config_from_cf.cf_releases ))
 
 director_uuid: (( config_from_cf.cf_director_uuid ))
 
@@ -116,7 +116,7 @@ resource_pools:
 
 jobs:
   - name: database_z1
-    templates: (( base_job_templates.database additional_jobs.database ))
+    templates: (( base_job_templates.database ))
     instances: (( instance_count_overrides.database_z1.instances || 1 ))
     persistent_disk: (( persistent_disk_overrides.database_z1 || 1024 ))
     resource_pool: database_z1
@@ -135,7 +135,7 @@ jobs:
         zone: z1
 
   - name: database_z2
-    templates: (( base_job_templates.database additional_jobs.database ))
+    templates: (( base_job_templates.database ))
     instances: (( instance_count_overrides.database_z2.instances || 1 ))
     persistent_disk: (( persistent_disk_overrides.database_z2 || 1024 ))
     resource_pool: database_z2
@@ -154,7 +154,7 @@ jobs:
         zone: z2
 
   - name: database_z3
-    templates: (( base_job_templates.database additional_jobs.database ))
+    templates: (( base_job_templates.database ))
     instances: (( instance_count_overrides.database_z3.instances || 1 ))
     persistent_disk: (( persistent_disk_overrides.database_z3 || 1024 ))
     resource_pool: database_z3
@@ -173,7 +173,7 @@ jobs:
         zone: z3
 
   - name: brain_z1
-    templates: (( base_job_templates.brain additional_jobs.brain ))
+    templates: (( base_job_templates.brain ))
     instances: (( instance_count_overrides.brain_z1.instances || 1 ))
     resource_pool: brain_z1
     networks:
@@ -190,7 +190,7 @@ jobs:
         zone: z1
 
   - name: cell_z1
-    templates: (( base_job_templates.cell additional_jobs.cell ))
+    templates: (( base_job_templates.cell ))
     instances: (( instance_count_overrides.cell_z1.instances || 1 ))
     resource_pool: cell_z1
     networks:
@@ -206,7 +206,7 @@ jobs:
           zone: z1
 
   - name: cc_bridge_z1
-    templates: (( base_job_templates.cc_bridge additional_jobs.cc_bridge ))
+    templates: (( base_job_templates.cc_bridge ))
     instances: (( instance_count_overrides.cc_bridge_z1.instances || 1 ))
     resource_pool: cc_bridge_z1
     networks:
@@ -226,7 +226,7 @@ jobs:
             tps: {}
 
   - name: route_emitter_z1
-    templates: (( base_job_templates.route_emitter additional_jobs.route_emitter ))
+    templates: (( base_job_templates.route_emitter ))
     instances: (( instance_count_overrides.route_emitter_z1.instances || 1 ))
     resource_pool: route_emitter_z1
     networks:
@@ -239,7 +239,7 @@ jobs:
         zone: z1
 
   - name: access_z1
-    templates: (( base_job_templates.access additional_jobs.access))
+    templates: (( base_job_templates.access ))
     instances: (( instance_count_overrides.access_z1.instances || 1 ))
     resource_pool: access_z1
     networks:
@@ -258,7 +258,7 @@ jobs:
             ssh_proxy: {}
 
   - name: brain_z2
-    templates: (( base_job_templates.brain additional_jobs.brain ))
+    templates: (( base_job_templates.brain ))
     instances: (( instance_count_overrides.brain_z2.instances || 1 ))
     resource_pool: brain_z2
     networks:
@@ -275,7 +275,7 @@ jobs:
         zone: z2
 
   - name: cell_z2
-    templates: (( base_job_templates.cell additional_jobs.cell ))
+    templates: (( base_job_templates.cell ))
     instances: (( instance_count_overrides.cell_z2.instances || 1 ))
     resource_pool: cell_z2
     networks:
@@ -291,7 +291,7 @@ jobs:
           zone: z2
 
   - name: cc_bridge_z2
-    templates: (( base_job_templates.cc_bridge additional_jobs.cc_bridge ))
+    templates: (( base_job_templates.cc_bridge ))
     instances: (( instance_count_overrides.cc_bridge_z2.instances || 1 ))
     resource_pool: cc_bridge_z2
     networks:
@@ -311,7 +311,7 @@ jobs:
             tps: {}
 
   - name: route_emitter_z2
-    templates: (( base_job_templates.route_emitter additional_jobs.route_emitter ))
+    templates: (( base_job_templates.route_emitter ))
     instances: (( instance_count_overrides.route_emitter_z2.instances || 1 ))
     resource_pool: route_emitter_z2
     networks:
@@ -324,7 +324,7 @@ jobs:
         zone: z2
 
   - name: access_z2
-    templates: (( base_job_templates.access additional_jobs.access))
+    templates: (( base_job_templates.access ))
     instances: (( instance_count_overrides.access_z2.instances || 1 ))
     resource_pool: access_z2
     networks:
@@ -343,7 +343,7 @@ jobs:
             ssh_proxy: {}
 
   - name: brain_z3
-    templates: (( base_job_templates.brain additional_jobs.brain ))
+    templates: (( base_job_templates.brain ))
     instances: (( instance_count_overrides.brain_z3.instances || 0 ))
     resource_pool: brain_z3
     networks:
@@ -360,7 +360,7 @@ jobs:
         zone: z3
 
   - name: cell_z3
-    templates: (( base_job_templates.cell additional_jobs.cell ))
+    templates: (( base_job_templates.cell ))
     instances: (( instance_count_overrides.cell_z3.instances || 0 ))
     resource_pool: cell_z3
     networks:
@@ -376,7 +376,7 @@ jobs:
           zone: z3
 
   - name: cc_bridge_z3
-    templates: (( base_job_templates.cc_bridge additional_jobs.cc_bridge ))
+    templates: (( base_job_templates.cc_bridge ))
     instances: (( instance_count_overrides.cc_bridge_z3.instances || 0 ))
     resource_pool: cc_bridge_z3
     networks:
@@ -396,7 +396,7 @@ jobs:
             tps: {}
 
   - name: route_emitter_z3
-    templates: (( base_job_templates.route_emitter additional_jobs.route_emitter ))
+    templates: (( base_job_templates.route_emitter ))
     instances: (( instance_count_overrides.route_emitter_z3.instances || 0 ))
     resource_pool: route_emitter_z3
     networks:
@@ -409,7 +409,7 @@ jobs:
         zone: z3
 
   - name: access_z3
-    templates: (( base_job_templates.access additional_jobs.access))
+    templates: (( base_job_templates.access ))
     instances: (( instance_count_overrides.access_z3.instances || 0 ))
     resource_pool: access_z3
     networks:
@@ -428,7 +428,7 @@ jobs:
             ssh_proxy: {}
 
   - name: colocated_z1
-    templates: (( base_job_templates.colocated additional_jobs.colocated ))
+    templates: (( base_job_templates.colocated ))
     instances: (( instance_count_overrides.colocated_z1.instances || 0 ))
     persistent_disk: (( persistent_disk_overrides.colocated_z1 || 1024 ))
     resource_pool: colocated_z1
@@ -458,7 +458,7 @@ jobs:
         zone: z1
 
   - name: colocated_z2
-    templates: (( base_job_templates.colocated additional_jobs.colocated ))
+    templates: (( base_job_templates.colocated ))
     instances: (( instance_count_overrides.colocated_z2.instances || 0 ))
     persistent_disk: (( persistent_disk_overrides.colocated_z2 || 1024 ))
     resource_pool: colocated_z2
@@ -488,7 +488,7 @@ jobs:
         zone: z2
 
   - name: colocated_z3
-    templates: (( base_job_templates.colocated additional_jobs.colocated ))
+    templates: (( base_job_templates.colocated ))
     instances: (( instance_count_overrides.colocated_z3.instances || 0 ))
     persistent_disk: (( persistent_disk_overrides.colocated_z3 || 1024 ))
     resource_pool: colocated_z3
@@ -773,18 +773,9 @@ properties:
 # The keys below should not be included in the final stub
 config_from_cf: (( merge ))
 iaas_settings: (( merge ))
-instance_count_overrides: (( merge ))
-persistent_disk_overrides: (( merge ))
+instance_count_overrides: (( merge || nil ))
+persistent_disk_overrides: (( merge || nil ))
 property_overrides: (( merge ))
-additional_jobs:
-  access: (( merge || [] ))
-  brain: (( merge || [] ))
-  cc_bridge: (( merge || [] ))
-  cell: (( merge || [] ))
-  colocated: (( merge || [] ))
-  database: (( merge || [] ))
-  releases: (( merge || [] ))
-  route_emitter: (( merge || [] ))
 release_versions: (( merge || nil ))
 base_releases:
   - name: diego

--- a/scripts/generate-deployment-manifest
+++ b/scripts/generate-deployment-manifest
@@ -6,36 +6,66 @@ manifest_generation=$(dirname $0)/../manifest-generation
 
 function usage() {
   >&2 echo "    Usage:
-    $0 /path/to/stub/property-overrides.yml \\
-       /path/to/stub/instance-count-overrides.yml \\
-       /path/to/stub/persistent-disk-overrides.yml \\
-       /path/to/stub/iaas-settings.yml \\
-       /path/to/stub/additional-jobs.yml \\
-       /path/to/stub/release-versions.yml \\
-       /path/to/deployment-manifests
+    $0 <MANDATORY ARGUMENTS> [OPTIONAL ARGUMENTS]
+    Mandatory arguments:
+       -c CF manifest file
+       -i IaaS-settings stub file 
+       -p property-overrides stub file 
+    Optional arguments:
+       -n instance-count-overrides stub file 
+       -k persistent-disk overrides stub file 
+       -v release-versions stub file 
 
-    Ex:
-    $0 manifest-generation/bosh-lite-stubs/property-overrides.yml \\
-       manifest-generation/bosh-lite-stubs/instance-count-overrides.yml \\
-       manifest-generation/bosh-lite-stubs/persistent-disk-overrides.yml \\
-       manifest-generation/bosh-lite-stubs/iaas-settings.yml \\
-       manifest-generation/bosh-lite-stubs/additional-jobs.yml \\
-       manifest-generation/bosh-lite-stubs/release-versions.yml \\
-       ~/deployments/bosh-lite
+    Example:
+    $0 -c ~/deployments/cf.yml \\
+       -i manifest-generation/bosh-lite-stubs/iaas-settings.yml \\
+       -p manifest-generation/bosh-lite-stubs/property-overrides.yml \\
+       -n manifest-generation/bosh-lite-stubs/instance-count-overrides.yml \\
+       -k manifest-generation/bosh-lite-stubs/persistent-disk-overrides.yml \\
+       -v manifest-generation/bosh-lite-stubs/release-versions.yml
 "
   exit 1
 }
 
-if [ "$#" -eq 7 ]; then
-  property_overrides=$1
-  instance_counts=$2
-  persistent_disk=$3
-  iaas_settings=$4
-  additional_jobs=$5
-  release_versions=$6
-  deployments=$7
-else
-  >&2 echo "Incorrect number of arguments"
+while getopts "c:i:p:n:k:v:" opt; do
+  case $opt in
+    c)
+      deployments=$OPTARG
+      ;;
+    i)
+      iaas_settings=$OPTARG
+      ;;
+    p)
+      property_overrides=$OPTARG
+      ;;
+    n)
+      instance_counts=$OPTARG
+      ;;
+    k)
+      persistent_disk=$OPTARG
+      ;;
+    v)
+      release_versions=$OPTARG
+      ;;
+    *)
+      echo "Unknown arguments"
+      usage
+      ;;
+  esac
+done
+
+if [ -z ${deployments} ]; then
+  >&2 echo "CF manifest file is missing"
+  usage
+fi
+
+if [ -z ${iaas_settings} ]; then
+  >&2 echo "IaaS-settings stub file is missing"
+  usage
+fi
+
+if [ -z ${property_overrides} ]; then
+  >&2 echo "property-overrides stub file is missing"
   usage
 fi
 
@@ -44,12 +74,12 @@ if [ ! -f "${property_overrides}" ]; then
   usage
 fi
 
-if [ ! -f "${instance_counts}" ]; then
+if [[ ! -z "${instance_counts}" && ! -f "${instance_counts}" ]]; then
   >&2 echo "Instance Count Overrides stub '${instance_counts}' is not a regular file"
   usage
 fi
 
-if [ ! -f "${persistent_disk}" ]; then
+if [[ ! -z "${persistent_disk}" && ! -f "${persistent_disk}" ]]; then
   >&2 echo "Persistent Disk Overrides stub '${persistent_disk}' is not a regular file"
   usage
 fi
@@ -59,18 +89,13 @@ if [ ! -f "${iaas_settings}" ]; then
   usage
 fi
 
-if [ ! -f "${additional_jobs}" ]; then
-  >&2 echo "Additional Jobs stub '${additional_jobs}' is not a regular file"
-  usage
-fi
-
-if [ ! -f "${release_versions}" ]; then
+if [[ ! -z "${release_versions}" && ! -f "${release_versions}" ]]; then
   >&2 echo "Release versions stub '${release_versions}' is not a regular file"
   usage
 fi
 
-if [ ! -d "${deployments}" ]; then
-  >&2 echo "Deployments directory '${deployments}' is not a directory"
+if [ ! -f "${deployments}" ]; then
+  >&2 echo "CF manifest '${deployments}' is not a regular file"
   usage
 fi
 
@@ -79,7 +104,7 @@ tmpdir=$(mktemp -d /tmp/diego-manifest.XXXXX)
 spiff merge \
   ${manifest_generation}/config-from-cf.yml \
   ${manifest_generation}/config-from-cf-internal.yml \
-  ${deployments}/cf.yml \
+  ${deployments} \
   > ${tmpdir}/config-from-cf.yml
 
 spiff merge \
@@ -88,7 +113,6 @@ spiff merge \
   ${instance_counts} \
   ${persistent_disk} \
   ${iaas_settings} \
-  ${additional_jobs} \
   ${release_versions} \
   ${tmpdir}/config-from-cf.yml \
   > ${tmpdir}/diego.yml


### PR DESCRIPTION
I believe it is not a good practice to hardcode `cf.yml` as an only name of source CF manifest. In my practice, I keep at least two CF manifests in same directory - for Regular and Tiny deployment.

Because of that, it would be nice to set not just a directory, but full filename for source manifest. For backward compatibility, I've added concatenation with `/cf.yml` when directory is provided as a source.