### PR TITLE
Added a variable to disable failfast

### DIFF
--- a/jobs/acceptance-tests/spec
+++ b/jobs/acceptance-tests/spec
@@ -39,6 +39,9 @@ properties:
   acceptance_tests.skip_docker_tests:
     default: false
     description: Skip tests that exercise docker support
+  acceptance_tests.failfast:
+    description: Skip all of the rest, if one of tests fails
+    default: true
   acceptance_tests.skip_regex:
     default: ""
     description: Regex for tests that should be skipped

--- a/jobs/acceptance-tests/templates/run.erb
+++ b/jobs/acceptance-tests/templates/run.erb
@@ -32,9 +32,11 @@ tags+=<%= p("acceptance_tests.skip_internet_tests") ? "noInternet," : "" %>
 tags+=<%= p("acceptance_tests.skip_docker_tests") ? "noDocker," : "" %>
 tags=${tags//,/ }
 
+failfast=<%= p("acceptance_tests.failfast") ? "-failFast" : "" %>
+
 nodes=<%= properties.acceptance_tests.nodes %>
 verbose=<%= properties.acceptance_tests.verbose ? "-v" : "" %>
-bin/test -randomizeAllSpecs $verbose -skipPackage=$packagesToSkip $skips -tags="${tags}" -nodes=$nodes -keepGoing || EXITSTATUS=$?
+bin/test -randomizeAllSpecs $failfast $verbose -skipPackage=$packagesToSkip $skips -tags="${tags}" -nodes=$nodes -keepGoing || EXITSTATUS=$?
 
 echo "Acceptance Tests Complete; exit status: $EXITSTATUS"
 


### PR DESCRIPTION
Default `-failFast` behaviour for **ginkgo** is annoying when you want to check each other test when a single one is failing.
I hope you will love this patch.
Appropriate patch for https://github.com/cloudfoundry-incubator/diego-acceptance-tests will be referred.