### PR TITLE
skip dea compatibility tests

### DIFF
--- a/jobs/acceptance-tests/templates/run.erb
+++ b/jobs/acceptance-tests/templates/run.erb
@@ -23,6 +23,7 @@ EXITSTATUS=0
 packagesToSkip=""
 packagesToSkip+=<%= p("acceptance_tests.run_security_groups_tests") ? "" : "security_groups," %>
 packagesToSkip+=<%= p("acceptance_tests.run_ssh_tests") ? "" : "ssh," %>
+packagesToSkip+=<%= p("acceptance_tests.skip_dea_compatibility? "" : "dea," %>
 [[ $packagesToSkip == *, ]] && packagesToSkip=${packagesToSkip%?}
 
 skips=<%= p("acceptance_tests.skip_regex") ? %Q[-skip="#{p("acceptance_tests.skip_regex")}"] : "" %>

--- a/manifest-generation/diego-acceptance-tests.yml
+++ b/manifest-generation/diego-acceptance-tests.yml
@@ -44,6 +44,7 @@ properties:
     admin_password: (( acceptance_tests_properties.admin_password ))
     secure_address: (( acceptance_tests_properties.secure_address ))
     skip_ssl_validation: (( acceptance_tests_properties.skip_cert_verify ))
+    skip_dea_validation: (( acceptance_tests_properties.skip_dea_compatibility ))
 
 # The keys below should not be included in the final stub
 config_from_cf: (( merge ))


### PR DESCRIPTION
For cf deployments with no DEA's, this test is not needed and should be skippable.