### PR TITLE
Remove cloudfoundry/cli from diego tree

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -246,10 +246,6 @@
 	path = src/github.com/cloudfoundry/sonde-go
 	url = https://github.com/cloudfoundry/sonde-go
 	branch = master
-[submodule "src/github.com/cloudfoundry/cli"]
-	path = src/github.com/cloudfoundry/cli
-	url = https://github.com/cloudfoundry/cli
-	branch = master
 [submodule "src/github.com/cloudfoundry-incubator/bbs"]
 	path = src/github.com/cloudfoundry-incubator/bbs
 	url = https://github.com/cloudfoundry-incubator/bbs

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ come from [cf-release](https://github.com/cloudfoundry/cf-release).
   - The [Diego Design Notes](https://github.com/cloudfoundry-incubator/diego-design-notes) present an overview of Diego, and links to the various Diego components.
   - The [Migration Guide](https://github.com/cloudfoundry-incubator/diego-design-notes/blob/master/migrating-to-diego.md) describes how developers and operators can manage a transition from the DEAs to Diego.
   - The [Docker Support Notes](https://github.com/cloudfoundry-incubator/diego-design-notes/blob/master/docker-support.md) describe how Diego runs Docker-image-based apps in Cloud Foundry.
-  - The [SSH Access Notes](https://github.com/cloudfoundry-incubator/diego-design-notes/blob/master/ssh-access-and-policy.md) describe how to use the Diego-SSH CLI plugin to connect to app instances running on Diego.
+  - The [SSH Access Notes](https://github.com/cloudfoundry-incubator/diego-design-notes/blob/master/ssh-access-and-policy.md) describe how Diego's SSH proxy and daemon can be used to connect to app instances running on Diego.
   - The [Diego-CF Compatibility Log](https://github.com/cloudfoundry-incubator/diego-cf-compatibility) records which versions of cf-release and diego-release are compatible, according to the Diego team's [automated testing pipeline](https://concourse.diego-ci.cf-app.com/?groups=diego).
   - [Diego's Pivotal Tracker project](https://www.pivotaltracker.com/n/projects/1003146) shows what we're working on these days.
 


### PR DESCRIPTION
This is associated with cloudfoundry-incubator/diego-ssh#16. After removing the cli plugin from diego-ssh, we no longer need the cli source in our tree to build with.

This change can be applied after the diego-ssh submodule is bumped in diego-release.