### PR TITLE
Fix CF releases link that actually points to Diego releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ git clean -ffd
 
 ### From a final release of CF
 
-On the CF Release [GitHub Releases](https://github.com/cloudfoundry-incubator/diego-release/releases) page,
+On the CF Release [GitHub Releases](https://github.com/cloudfoundry/cf-release/releases) page,
 recommended versions of Diego, Garden, and ETCD are listed with each CF Release.
 This is the easiest way to correlate releases.
 


### PR DESCRIPTION
This is exceptionally confusing when you're trying to figure out what Diego version you should be using with your CF release.