### PR TITLE
Update loggregator and metron properties to match latest loggregator

### DIFF
--- a/manifest-generation/config-from-cf-internal.yml
+++ b/manifest-generation/config-from-cf-internal.yml
@@ -23,7 +23,7 @@ config_from_cf:
     traffic_controller_url: (( "wss://doppler." properties.system_domain ":443" ))
     dropsonde_incoming_port: (( properties.loggregator.dropsonde_incoming_port ))
     tls:
-      ca: (( properties.loggregator.tls.ca ))
+      ca_cert: (( properties.loggregator.tls.ca_cert ))
   metron_endpoint:
     shared_secret: (( properties.metron_endpoint.shared_secret ))
   metron_agent:
@@ -31,9 +31,9 @@ config_from_cf:
     preferred_protocol: (( properties.metron_agent.preferred_protocol ))
     enable_buffer: (( properties.metron_agent.enable_buffer ))
     buffer_size: (( properties.metron_agent.buffer_size ))
-    tls_client:
-      cert: (( properties.metron_agent.tls_client.cert ))
-      key: (( properties.metron_agent.tls_client.key ))
+    tls:
+      client_cert: (( properties.metron_agent.tls.client_cert ))
+      client_key: (( properties.metron_agent.tls.client_key ))
   nats:
     user: (( properties.nats.user ))
     password: (( properties.nats.password ))
@@ -71,7 +71,7 @@ properties:
       machines: (( merge ))
     dropsonde_incoming_port: (( merge || nil ))
     tls:
-      ca: (( merge ))
+      ca_cert: (( merge ))
   loggregator_endpoint:
     shared_secret: (( merge ))
   metron_endpoint:
@@ -81,9 +81,9 @@ properties:
     preferred_protocol: (( merge ))
     enable_buffer: (( merge || nil ))
     buffer_size: (( merge || nil ))
-    tls_client:
-      cert: (( merge ))
-      key: (( merge ))
+    tls:
+      client_cert: (( merge ))
+      client_key: (( merge ))
   nats:
     user: (( merge ))
     password: (( merge ))

--- a/manifest-generation/config-from-cf.yml
+++ b/manifest-generation/config-from-cf.yml
@@ -23,16 +23,16 @@ config_from_cf:
     traffic_controller_url: (( merge ))
     dropsonde_incoming_port: (( merge ))
     tls:
-      ca: (( merge ))
+      ca_cert: (( merge ))
 
   metron_agent:
     dropsonde_incoming_port: (( merge ))
     preferred_protocol: (( merge ))
     enable_buffer: (( merge ))
     buffer_size: (( merge ))
-    tls_client:
-      cert: (( merge ))
-      key: (( merge ))
+    tls:
+      client_cert: (( merge ))
+      client_key: (( merge ))
 
   metron_endpoint:
     shared_secret: (( merge ))

--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -448,16 +448,16 @@ properties:
     preferred_protocol: (( config_from_cf.metron_agent.preferred_protocol ))
     enable_buffer: (( config_from_cf.metron_agent.enable_buffer ))
     buffer_size: (( config_from_cf.metron_agent.buffer_size ))
-    tls_client:
-      cert: (( config_from_cf.metron_agent.tls_client.cert ))
-      key: (( config_from_cf.metron_agent.tls_client.key ))
+    tls:
+      client_cert: (( config_from_cf.metron_agent.tls.client_cert ))
+      client_key: (( config_from_cf.metron_agent.tls.client_key ))
     dropsonde_incoming_port: (( config_from_cf.metron_agent.dropsonde_incoming_port ))
   loggregator:
     etcd:
       machines: (( config_from_cf.loggregator.etcd_machines ))
     dropsonde_incoming_port: (( config_from_cf.loggregator.dropsonde_incoming_port ))
     tls:
-      ca: (( config_from_cf.loggregator.tls.ca ))
+      ca_cert: (( config_from_cf.loggregator.tls.ca_cert ))
   metron_endpoint:
     shared_secret: (( config_from_cf.metron_endpoint.shared_secret ))
   syslog_daemon_config:


### PR DESCRIPTION
The loggregator team decided to change the TLS property names to more closely match the rest of CF.  This PR covers those name changes.

The corresponding story is [#112639903](https://www.pivotaltracker.com/story/show/112639903).
