### PR TITLE
Fix create, upload, and deploy command in Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ and then look up that commit's SHA in the diego-cf compatibility table.
 
         cd ~/workspace/cf-release
         bosh deployment bosh-lite/deployments/cf.yml
-        bosh create release --force &&
+        bosh create release --name diego --force &&
         bosh -n upload release &&
         bosh -n deploy
 


### PR DESCRIPTION
Command when pasted into terminal generates a release named ``bosh -n upload release &&``