### PR TITLE
Set consul.agent.domain property to cf.internal

### DIFF
--- a/manifest-generation/config-from-cf-internal.yml
+++ b/manifest-generation/config-from-cf-internal.yml
@@ -8,6 +8,7 @@ config_from_cf:
     srv_api_uri: (( properties.cc.srv_api_uri ))
   consul:
     datacenter: (( properties.consul.agent.datacenter ))
+    domain: (( properties.consul.agent.domain ))
     log_level: (( properties.consul.agent.log_level ))
     lan_servers: (( properties.consul.agent.servers.lan ))
     ca_cert: (( properties.consul.ca_cert ))
@@ -55,6 +56,7 @@ properties:
     srv_api_uri: (( merge ))
   consul:
     agent:
+      domain: (( merge ))
       log_level: (( merge ))
       datacenter: (( merge || nil ))
       servers:

--- a/manifest-generation/config-from-cf.yml
+++ b/manifest-generation/config-from-cf.yml
@@ -8,6 +8,7 @@ config_from_cf:
     srv_api_uri: (( merge ))
   consul:
     datacenter: (( merge ))
+    domain: (( merge ))
     log_level: (( merge ))
     lan_servers: (( merge ))
     ca_cert: (( merge ))

--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -468,6 +468,7 @@ properties:
   consul:
     agent:
       datacenter: (( config_from_cf.consul.datacenter ))
+      domain: (( config_from_cf.consul.domain ))
       log_level: (( config_from_cf.consul.log_level ))
       servers:
         lan: (( config_from_cf.consul.lan_servers ))


### PR DESCRIPTION
- Prepare for future addition of consul.agent.domain property
  in consul-release that will not have a default value

[#115461031]

Signed-off-by: George Dean <gdean@pivotal.io>