### PR TITLE
Update manifest template to have explicit etcd.advertise_urls_dns_suffix

### DIFF
--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -482,6 +482,7 @@ properties:
   # -- Properties below are used by the etcd from etcd-release --
   etcd:
     machines: ["etcd.service.cf.internal"]
+    advertise_urls_dns_suffix: "etcd.service.cf.internal"
     cluster:
       - name: "database_z1"
         instances: (( instance_count_overrides.database_z1.instances || 1 ))


### PR DESCRIPTION
See cloudfoundry-incubator/etcd-release#9 for details and cloudfoundry/cf-release#928 for the matching change in `cf-release`. This really only applies after `etcd-release` has been bumped, but there should be no issues doing things out of order.