### PR TITLE
Add a switch to control writing to /proc/sys

### DIFF
--- a/src/pid_utils.sh
+++ b/src/pid_utils.sh
@@ -138,5 +138,5 @@ file_must_include() {
 }
 
 running_in_container() {
-  grep -q '/instance' /proc/self/cgroup
+  grep -q -E '/instance|/docker/' /proc/self/cgroup
 }


### PR DESCRIPTION
Not all environments allow writing to /proc/sys, allow these to be
controlled via config setting.

There is already a check for running_in_container() but this seems to be bosh-lite specific as it's looking for a specific entry in /proc/self/cgroup.