### PR TITLE
Require consul certs and keys from cf manifest

### DIFF
--- a/manifest-generation/config-from-cf-internal.yml
+++ b/manifest-generation/config-from-cf-internal.yml
@@ -61,13 +61,12 @@ properties:
       datacenter: (( merge || nil ))
       servers:
         lan: (( merge ))
-    ca_cert: (( merge || nil ))
-    agent_cert: (( merge || nil ))
-    agent_key: (( merge || nil ))
-    encrypt_keys: (( merge || nil ))
-    require_ssl: (( merge || nil ))
-    server_cert: (( merge || nil ))
-    server_key: (( merge || nil ))
+    ca_cert: (( merge ))
+    agent_cert: (( merge ))
+    agent_key: (( merge ))
+    encrypt_keys: (( merge ))
+    server_cert: (( merge ))
+    server_key: (( merge ))
   loggregator:
     etcd:
       machines: (( merge ))


### PR DESCRIPTION
We are planning to remove support for non-ssl mode in consul. We've updated the spiff templates in cf-release to reflect that certs and keys need to be provided (see: https://github.com/cloudfoundry/cf-release/commit/86152769da8fb1b62386bf645087df360e312885).