### PR TITLE
Require consul certs and keys from cf manifest

### DIFF
--- a/manifest-generation/config-from-cf-internal.yml
+++ b/manifest-generation/config-from-cf-internal.yml
@@ -15,7 +15,6 @@ config_from_cf:
     agent_cert: (( properties.consul.agent_cert ))
     agent_key: (( properties.consul.agent_key ))
     encrypt_keys: (( properties.consul.encrypt_keys ))
-    require_ssl: (( properties.consul.require_ssl ))
     server_cert: (( properties.consul.server_cert ))
     server_key: (( properties.consul.server_key ))
   loggregator:

--- a/manifest-generation/config-from-cf-internal.yml
+++ b/manifest-generation/config-from-cf-internal.yml
@@ -60,13 +60,12 @@ properties:
       datacenter: (( merge || nil ))
       servers:
         lan: (( merge ))
-    ca_cert: (( merge || nil ))
-    agent_cert: (( merge || nil ))
-    agent_key: (( merge || nil ))
-    encrypt_keys: (( merge || nil ))
-    require_ssl: (( merge || nil ))
-    server_cert: (( merge || nil ))
-    server_key: (( merge || nil ))
+    ca_cert: (( merge ))
+    agent_cert: (( merge ))
+    agent_key: (( merge ))
+    encrypt_keys: (( merge ))
+    server_cert: (( merge ))
+    server_key: (( merge ))
   loggregator:
     etcd:
       machines: (( merge ))

--- a/manifest-generation/config-from-cf.yml
+++ b/manifest-generation/config-from-cf.yml
@@ -15,7 +15,6 @@ config_from_cf:
     agent_cert: (( merge ))
     agent_key: (( merge ))
     encrypt_keys: (( merge ))
-    require_ssl: (( merge ))
     server_cert: (( merge ))
     server_key: (( merge ))
   loggregator:

--- a/manifest-generation/diego-vizzini.yml
+++ b/manifest-generation/diego-vizzini.yml
@@ -57,7 +57,6 @@ properties:
     agent_cert: (( config_from_cf.consul.agent_cert ))
     agent_key: (( config_from_cf.consul.agent_key ))
     encrypt_keys: (( config_from_cf.consul.encrypt_keys ))
-    require_ssl: (( config_from_cf.consul.require_ssl ))
     server_cert: (( config_from_cf.consul.server_cert ))
     server_key: (( config_from_cf.consul.server_key ))
   vizzini:

--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -476,7 +476,6 @@ properties:
     agent_cert: (( config_from_cf.consul.agent_cert ))
     agent_key: (( config_from_cf.consul.agent_key ))
     encrypt_keys: (( config_from_cf.consul.encrypt_keys ))
-    require_ssl: (( config_from_cf.consul.require_ssl ))
     server_cert: (( config_from_cf.consul.server_cert ))
     server_key: (( config_from_cf.consul.server_key ))
 


### PR DESCRIPTION
We are planning to remove support for non-ssl mode in consul. We've updated the spiff templates in cf-release to reflect that certs and keys need to be provided and require_ssl is no longer needed (see: https://github.com/cloudfoundry/cf-release/commit/86152769da8fb1b62386bf645087df360e312885, https://github.com/cloudfoundry/cf-release/commit/93beb219f7b3f25d28e4cd1ce7cea56fa243e0f0, and https://github.com/cloudfoundry/cf-release/commit/301b8ab2cfccb931cd74e5b99ba5fa9a41532b71).