### PR TITLE
Added transport to syslog_daemon_config in diego.yml

### DIFF
--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -463,6 +463,7 @@ properties:
   syslog_daemon_config:
     address: (( property_overrides.syslog_daemon_config.address || nil ))
     port: (( property_overrides.syslog_daemon_config.port || nil ))
+    transport: (( property_overrides.syslog_daemon_config.transport || tcp ))
 
   # -- Properties below are used by the consul_agent job from cf-release --
   consul:


### PR DESCRIPTION
We've been investigating why the transport information from our properties-overrides.yml has not been ended up in the final Diego manifest. We came up with the solution of adding the transport key to the diego.yml. Although we don't know if that's actually a proper fix or if it just works for us. Feedback very welcome!


Tom and Felix from Springer Nature