### PR TITLE
Update fingerprint generation command

### DIFF
--- a/examples/aws/README.md
+++ b/examples/aws/README.md
@@ -380,7 +380,18 @@ To enable SSH access to CF instances running on Diego, generate a host key and f
 
 ```bash
 ssh-keygen -f $DEPLOYMENT_DIR/keypair/ssh-proxy-host-key.pem
+```
+
+If you're running at least OSX 10.11 El Capitan or Ubuntu 16.04 Xenial Xerus then you may generate your MD5 fingerprint with:
+
+```bash
 ssh-keygen -lf $DEPLOYMENT_DIR/keypair/ssh-proxy-host-key.pem.pub -E md5 | cut -d ' ' -f2 | sed 's/MD5://g' > $DEPLOYMENT_DIR/keypair/ssh-proxy-host-key-fingerprint
+```
+
+Otherwise you may generate your MD5 fingerprint with:
+
+```bash
+ssh-keygen -lf $DEPLOYMENT_DIR/keypair/ssh-proxy-host-key.pem.pub | cut -d ' ' -f2 > $DEPLOYMENT_DIR/keypair/ssh-proxy-host-key-fingerprint
 ```
 
 The `ssh-proxy-host-key.pem` file contains the PEM-encoded private host key for the Diego manifest, and the `ssh-proxy-host-key-fingerprint` file contains the MD5 fingerprint of the public host key. You will later copy these values into stubs for generating the CF and Diego manifests.

--- a/examples/aws/README.md
+++ b/examples/aws/README.md
@@ -380,7 +380,7 @@ To enable SSH access to CF instances running on Diego, generate a host key and f
 
 ```bash
 ssh-keygen -f $DEPLOYMENT_DIR/keypair/ssh-proxy-host-key.pem
-ssh-keygen -lf $DEPLOYMENT_DIR/keypair/ssh-proxy-host-key.pem.pub | cut -d ' ' -f2 > $DEPLOYMENT_DIR/keypair/ssh-proxy-host-key-fingerprint
+ssh-keygen -lf $DEPLOYMENT_DIR/keypair/ssh-proxy-host-key.pem.pub -E md5 | cut -d ' ' -f2 | sed 's/MD5://g' > $DEPLOYMENT_DIR/keypair/ssh-proxy-host-key-fingerprint
 ```
 
 The `ssh-proxy-host-key.pem` file contains the PEM-encoded private host key for the Diego manifest, and the `ssh-proxy-host-key-fingerprint` file contains the MD5 fingerprint of the public host key. You will later copy these values into stubs for generating the CF and Diego manifests.


### PR DESCRIPTION
While following the AWS guide, we ran into issues with the fingerprint which was generated. The guide currently creates a `SHA256` fingerprint, and this pull request changes the `ssh-keygen` command to generate an `md5` fingerprint.

Without this change we were getting the following error message while attempting to SSH into an app deployed onto our CF installation.

```
○ → cf ssh dora -i 0
FAILED
Error opening SSH connection: ssh: handshake failed: Unsupported host key fingerprint format
```

As well as the following acceptance-tests failues

```
[Fail] {NO_DEA_SUPPORT} SSH ssh [It] can execute a remote command in the container
/Users/pivotal/go/src/github.com/cloudfoundry/cf-acceptance-tests/ssh/ssh_test.go:68

[Fail] {NO_DEA_SUPPORT} SSH ssh [It] runs an interactive session when no command is provided
/Users/pivotal/go/src/github.com/cloudfoundry/cf-acceptance-tests/ssh/ssh_test.go:105

[Fail] {NO_DEA_SUPPORT} SSH ssh [It] allows local port forwarding
/Users/pivotal/go/src/github.com/cloudfoundry/cf-acceptance-tests/ssh/ssh_test.go:126
```

cc @kkallday