### PR TITLE
Volman driver can be colocated on the Cell

### DIFF
--- a/jobs/rep/spec
+++ b/jobs/rep/spec
@@ -135,6 +135,7 @@ properties:
     description: "Experimental: user to run post setup hook command"
   diego.executor.volman.driver_paths:
     description: "Experimental: OS style path string containing the directories volman will look in for voldriver specs (delimited by : or ; depending on the OS)"
+    default: "/var/vcap/data/voldrivers"
 
   diego.rep.bbs.api_location:
     description: "Address to the BBS Server"

--- a/jobs/rep/templates/rep_ctl.erb
+++ b/jobs/rep/templates/rep_ctl.erb
@@ -93,6 +93,9 @@ case $1 in
     # Work around for GOLANG 1.5.3 DNS bug
     export GODEBUG=netdns=cgo
 
+    DRIVERS_PATHS=<%= p("diego.executor.volman.driver_paths") %>
+    mkdir -p $DRIVERS_PATHS
+    chown vcap:vcap $DRIVERS_PATHS
 
     chpst -u vcap:vcap /var/vcap/packages/rep/bin/rep ${bbs_sec_flags} \
       -bbsAddress=${bbs_api_url} \
@@ -138,6 +141,7 @@ case $1 in
         <% end %> \
       <% end %> \
       -tempDir=$TMP_DIR \
+      -volmanDriverConfigDir=$DRIVERS_PATHS \
       -logLevel=<%= p("diego.rep.log_level") %> \
       -gardenHealthcheckInterval=<%= p("diego.executor.garden_healthcheck.interval") %> \
       -gardenHealthcheckTimeout=<%= p("diego.executor.garden_healthcheck.timeout") %> \

--- a/jobs/rep/templates/rep_ctl.erb
+++ b/jobs/rep/templates/rep_ctl.erb
@@ -141,7 +141,7 @@ case $1 in
         <% end %> \
       <% end %> \
       -tempDir=$TMP_DIR \
-      -volmanDriverConfigDir=$DRIVERS_PATHS \
+      -volmanDriverPaths=$DRIVERS_PATHS \
       -logLevel=<%= p("diego.rep.log_level") %> \
       -gardenHealthcheckInterval=<%= p("diego.executor.garden_healthcheck.interval") %> \
       -gardenHealthcheckTimeout=<%= p("diego.executor.garden_healthcheck.timeout") %> \
@@ -162,9 +162,6 @@ case $1 in
       <% end %> \
       <% if_p("diego.executor.post_setup_hook") do |value| %> \
         -postSetupHook=<%= Shellwords.shellescape(value) %> \
-      <% end %> \
-      <% if_p("diego.executor.volman.driver_paths") do |value| %> \
-        -volmanDriverPaths=<%= value %> \
       <% end %> \
       2>> $LOG_DIR/rep.stderr.log \
       1> >(tee -a $LOG_DIR/rep.stdout.log | logger -t vcap.rep) &

--- a/manifest-generation/bosh-lite-stubs/experimental/voldriver/drivers.yml
+++ b/manifest-generation/bosh-lite-stubs/experimental/voldriver/drivers.yml
@@ -1,9 +1,8 @@
-drivers:
-  template:
-     - name: cephdriver
-       release: cephfs-bosh-release
-
 volman_overrides:
-   release:
+  release:
     - name: cephfs-bosh-release
       version: "latest"
+  drivers:
+    template:
+    - name: cephdriver
+      release: cephfs-bosh-release

--- a/manifest-generation/bosh-lite-stubs/experimental/voldriver/drivers.yml
+++ b/manifest-generation/bosh-lite-stubs/experimental/voldriver/drivers.yml
@@ -1,0 +1,9 @@
+drivers:
+  template:
+     - name: cephdriver
+       release: cephfs-bosh-release
+
+volman_overrides:
+   release:
+    - name: cephfs-bosh-release
+      version: "latest"

--- a/manifest-generation/bosh-lite-stubs/property-overrides.yml
+++ b/manifest-generation/bosh-lite-stubs/property-overrides.yml
@@ -381,6 +381,8 @@ property_overrides:
       network: tcp
       address: 127.0.0.1:7777
     log_level: debug
+    volman:
+      driver_paths: /var/vcap/data/voldrivers
   garden:
     listen_network: tcp
     listen_address: 0.0.0.0:7777

--- a/manifest-generation/bosh-lite-stubs/property-overrides.yml
+++ b/manifest-generation/bosh-lite-stubs/property-overrides.yml
@@ -381,8 +381,6 @@ property_overrides:
       network: tcp
       address: 127.0.0.1:7777
     log_level: debug
-    volman:
-      driver_paths: /var/vcap/data/voldrivers
   garden:
     listen_network: tcp
     listen_address: 0.0.0.0:7777

--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -1,6 +1,6 @@
 name: (( config_from_cf.cf_deployment_name "-diego" ))
 
-releases: (( base_releases [garden_overrides.release] [config_from_cf.cf_release] ))
+releases: (( base_releases volman_overrides.release [garden_overrides.release] [config_from_cf.cf_release] ))
 
 director_uuid: (( config_from_cf.cf_director_uuid ))
 
@@ -188,7 +188,7 @@ jobs:
         zone: z1
 
   - name: cell_z1
-    templates: (( base_job_templates.cell ))
+    templates: ((  base_job_templates.cell drivers.template ))
     instances: (( instance_count_overrides.cell_z1.instances || 1 ))
     resource_pool: cell_z1
     networks:
@@ -716,6 +716,8 @@ garden_overrides:
     name: garden-linux
     version: (( release_versions.garden_linux || "latest" ))
 empty_hash: {}
+volman_overrides:
+  release: (( merge || [] ))
 base_releases:
   - name: diego
     version: (( release_versions.diego || "latest" ))
@@ -724,6 +726,9 @@ base_releases:
   - name: cflinuxfs2-rootfs
     version: (( release_versions.etcd || "latest" ))
 release_versions: (( merge || nil ))
+drivers:
+ template: (( merge || [] ))
+
 base_job_templates:
   access:
     - name: consul_agent

--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -188,7 +188,7 @@ jobs:
         zone: z1
 
   - name: cell_z1
-    templates: ((  base_job_templates.cell drivers.template ))
+    templates: ((  base_job_templates.cell volman_overrides.drivers.template ))
     instances: (( instance_count_overrides.cell_z1.instances || 1 ))
     resource_pool: cell_z1
     networks:
@@ -585,8 +585,6 @@ properties:
           env: (( property_overrides.executor.garden_healthcheck.process.env || nil ))
       ca_certs_for_downloads: (( property_overrides.executor.ca_certs_for_downloads || nil ))
       log_level: (( property_overrides.executor.log_level || nil ))
-      volman:
-        driver_paths: (( property_overrides.executor.volman.driver_paths || nil ))
     file_server:
       dropsonde_port: (( config_from_cf.metron_agent.dropsonde_incoming_port ))
       log_level: (( property_overrides.file_server.log_level || nil ))
@@ -718,8 +716,7 @@ garden_overrides:
     name: garden-linux
     version: (( release_versions.garden_linux || "latest" ))
 empty_hash: {}
-volman_overrides:
-  release: (( merge || [] ))
+volman_overrides: (( merge || [] ))
 base_releases:
   - name: diego
     version: (( release_versions.diego || "latest" ))
@@ -728,8 +725,6 @@ base_releases:
   - name: cflinuxfs2-rootfs
     version: (( release_versions.etcd || "latest" ))
 release_versions: (( merge || nil ))
-drivers:
- template: (( merge || [] ))
 
 base_job_templates:
   access:

--- a/manifest-generation/diego.yml
+++ b/manifest-generation/diego.yml
@@ -585,6 +585,8 @@ properties:
           env: (( property_overrides.executor.garden_healthcheck.process.env || nil ))
       ca_certs_for_downloads: (( property_overrides.executor.ca_certs_for_downloads || nil ))
       log_level: (( property_overrides.executor.log_level || nil ))
+      volman:
+        driver_paths: (( property_overrides.executor.volman.driver_paths || nil ))
     file_server:
       dropsonde_port: (( config_from_cf.metron_agent.dropsonde_incoming_port ))
       log_level: (( property_overrides.file_server.log_level || nil ))

--- a/scripts/generate-bosh-lite-manifests
+++ b/scripts/generate-bosh-lite-manifests
@@ -15,6 +15,12 @@ if [ ! -z ${USE_SQL} ]; then
   sql_option="-s manifest-generation/bosh-lite-stubs/experimental/mysql/diego-sql.yml"
 fi
 
+if [ ! -d ${ENABLE_VOLDRIVER} ]; then
+  voldriver_option="-d manifest-generation/bosh-lite-stubs/experimental/voldriver/drivers.yml"
+fi
+
+
+
 pushd ${DIEGO_RELEASE_DIR}
 	$scripts_path/generate-deployment-manifest \
 			-c ${CF_MANIFESTS_DIR}/cf.yml \
@@ -22,6 +28,7 @@ pushd ${DIEGO_RELEASE_DIR}
 			-p manifest-generation/bosh-lite-stubs/property-overrides.yml \
 			-n manifest-generation/bosh-lite-stubs/instance-count-overrides.yml \
 			${sql_option} \
+			${voldriver_option} \
 			-v manifest-generation/bosh-lite-stubs/release-versions.yml \
 			"$@" \
 			> ${DIEGO_MANIFESTS_DIR}/diego.yml

--- a/scripts/generate-deployment-manifest
+++ b/scripts/generate-deployment-manifest
@@ -22,6 +22,7 @@ OPTIONAL ARGUMENTS:
     -v <versions-path>  Path to release-versions stub file.
     -s <sql-db-path>    Path to SQL stub file.
     -g                  Opt into using garden-runc-release for cells.
+    -d <voldriver-path> Path to voldriver stub file.
 
 EXAMPLE:
     $0 \\
@@ -31,6 +32,7 @@ EXAMPLE:
       -n manifest-generation/bosh-lite-stubs/instance-count-overrides.yml \\
       -v manifest-generation/bosh-lite-stubs/release-versions.yml \\
       -s manifest-generation/bosh-lite-stubs/diego-sql.yml \\
+      -d manifest-generation/bosh-lite-stubs/experimental/voldriver/drivers.yml \\
       -g
 EOF
   exit 1
@@ -39,7 +41,7 @@ EOF
 base_releases="${manifest_generation}/base-releases.yml"
 garden_properties=""
 
-while getopts "c:i:p:n:k:v:s:rbg" opt; do
+while getopts "c:i:p:n:k:v:s:d:rbg" opt; do
   case $opt in
     c)
       cf_deployment_manifest=$OPTARG
@@ -67,6 +69,9 @@ while getopts "c:i:p:n:k:v:s:rbg" opt; do
       ;;
     s)
       sql_settings=$OPTARG
+      ;;
+    d)
+      voldriver_settings=$OPTARG
       ;;
     *)
       echo "Unknown arguments"
@@ -111,6 +116,11 @@ if [[ ! -z "${sql_settings}" && ! -f "${sql_settings}" ]]; then
   argument_error=true
 fi
 
+if [[ ! -z "${voldriver_settings}" && ! -f "${voldriver_settings}" ]]; then
+  >&2 echo "ERROR: Voldriver Setting stub '${voldriver_settings}' is not a regular file"
+  argument_error=true
+fi
+
 if [[ ! -z "${instance_counts}" && ! -f "${instance_counts}" ]]; then
   >&2 echo "ERROR: Instance-count-overrides stub '${instance_counts}' is not a regular file"
   argument_error=true
@@ -141,6 +151,7 @@ spiff merge \
   ${property_overrides} \
   ${instance_counts} \
   ${sql_settings} \
+  ${voldriver_settings} \
   ${iaas_settings} \
   ${tmpdir}/config-from-cf.yml \
   > ${tmpdir}/diego.yml


### PR DESCRIPTION
-  Added stub for volman drivers in  `manifest-generation/bosh-lite-stubs/experimental/voldriver/`
- Modified diego.yml to include tags for spiff merging the voldrivers and their bosh-releases
- Modified scripts for manifest generation to include an optional driver colocated with the cell
  [#112362783](https://www.pivotaltracker.com/story/show/112362783)

Signed-off-by: Nagapramod Mandagere <pramod@us.ibm.com>
Signed-off-by: Julian Hjortshoj <julian.hjortshoj@emc.com>